### PR TITLE
Initialize scope in provider

### DIFF
--- a/providers/sentry_provider.ts
+++ b/providers/sentry_provider.ts
@@ -13,6 +13,12 @@ export default class MonitoringProvider {
       SentrySDK.init(config)
     }
 
-    this.app.container.bind(Sentry, () => new SentrySDK.Scope())
+    this.app.container.bind(Sentry, () => {
+      const client = SentrySDK.getClient()
+      const scope = new SentrySDK.Scope()
+      scope.setClient(client)
+
+      return scope
+    })
   }
 }


### PR DESCRIPTION
The sentry scope is not being initialized in the Provider. Which prevented sending errors to sentry outside of the HttpContext.