### PR TITLE
fix: remove scoping

### DIFF
--- a/providers/sentry_provider.ts
+++ b/providers/sentry_provider.ts
@@ -1,24 +1,15 @@
-import * as SentrySDK from '@sentry/node'
 import { Sentry } from '../src/sentry.js'
 import type { ApplicationService } from '@adonisjs/core/types'
 import type { SentryConfig } from '../src/types/main.js'
 
-export default class MonitoringProvider {
+export default class SentryProvider {
   constructor(protected app: ApplicationService) {}
 
   async boot() {
     const config = this.app.config.get<SentryConfig>('sentry', {})
 
     if (config.enabled) {
-      SentrySDK.init(config)
+      Sentry.init(config)
     }
-
-    this.app.container.bind(Sentry, () => {
-      const client = SentrySDK.getClient()
-      const scope = new SentrySDK.Scope()
-      scope.setClient(client)
-
-      return scope
-    })
   }
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,37 +7,22 @@
  * file that was distributed with this source code.
  */
 
-import * as SentrySDK from '@sentry/node'
 import { Sentry } from './sentry.js'
 import type { HttpContext } from '@adonisjs/core/http'
 import type { NextFn } from '@adonisjs/core/types/http'
 
 export default class SentryMiddleware {
   async handle(ctx: HttpContext, next: NextFn) {
-    const client = SentrySDK.getClient()
-    const scope = new SentrySDK.Scope()
+    Sentry.setTag('url', ctx.request.url())
 
-    scope.setClient(client)
-    scope.setTag('url', ctx.request.url())
-
-    ctx.sentry = scope
-    ctx.containerResolver.bindValue(Sentry, scope)
-
-    await SentrySDK.startSpan(
+    await Sentry.startSpan(
       {
         name: ctx.routeKey || 'unknown',
         op: 'http.server',
-        scope,
       },
       async () => {
         await next()
       }
     )
-  }
-}
-
-declare module '@adonisjs/core/http' {
-  export interface HttpContext {
-    sentry: SentrySDK.Scope
   }
 }

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -7,6 +7,6 @@
  * file that was distributed with this source code.
  */
 
-import * as SentrySDK from '@sentry/node'
+import * as Sentry from '@sentry/node'
 
-export abstract class Sentry extends SentrySDK.Scope {}
+export { Sentry }

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -7,9 +7,9 @@
  * file that was distributed with this source code.
  */
 
-import * as SentrySDK from '@sentry/node'
+import * as Sentry from '@sentry/node'
 
-export interface SentryConfig extends SentrySDK.NodeOptions {
+export interface SentryConfig extends Sentry.NodeOptions {
   /**
    * Enable or disable Sentry
    */


### PR DESCRIPTION
This PR fixes #5.

It is a breaking change, because Sentry will not be available in the IoC container or HttpContext anymore, scoping will be handled by the Sentry SDK which is the recommended approach by Sentry's developers.