### PR TITLE
fix: middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,16 +13,13 @@ import type { NextFn } from '@adonisjs/core/types/http'
 
 export default class SentryMiddleware {
   async handle(ctx: HttpContext, next: NextFn) {
-    Sentry.setTag('url', ctx.request.url())
+    const activeSpan = Sentry.getActiveSpan()
+    const rootSpan = activeSpan && Sentry.getRootSpan(activeSpan)
 
-    await Sentry.startSpan(
-      {
-        name: ctx.routeKey || 'unknown',
-        op: 'http.server',
-      },
-      async () => {
-        await next()
-      }
-    )
+    if (rootSpan) {
+      Sentry.updateSpanName(rootSpan, ctx.routeKey || 'unknown')
+    }
+
+    return next()
   }
 }


### PR DESCRIPTION
Sentry automatically creates a root span (transaction) on every request. Instead of manually creating a new span in the middleware with the same operation but with less data, we can simply update the root span.

Fixes #16