### PR TITLE
Fix: sentry provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "yarn clean && tsc && yarn copy:templates",
     "clean": "del-cli build",
-    "copy:templates": "copyfiles \"stubs/**/*.stub\" --up=\"1\" build",
+    "copy:templates": "copyfiles \"stubs/**/*.stub\" build",
     "format": "prettier --write .",
     "lint": "eslint . --ext=.ts",
     "prepublishOnly": "yarn build",

--- a/providers/sentry_provider.ts
+++ b/providers/sentry_provider.ts
@@ -10,6 +10,9 @@ export default class SentryProvider {
 
     if (config.enabled) {
       Sentry.init(config)
+
+      await import('node:http')
+      await import('node:https')
     }
   }
 }


### PR DESCRIPTION
I found out the [automatic transaction creation](https://github.com/RomainLanz/sentry/issues/16#issue-2934523177) only happens when Sentry patches the **http** and **https** node modules. However, this patch is only applied after those modules are referenced in the application. In my project I had a preload file that used axios, and this alone has been triggering the module patch. Without this patch, you do not get the automatic transaction. So to make sure it's applied for everyone, let's do the import in the provider.