### PR TITLE
Copy stubs files to build/stubs on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "yarn clean && tsc && yarn copy:templates",
     "clean": "del-cli build",
-    "copy:templates": "copyfiles \"stubs/**/*.stub\" --up=\"1\" build",
+    "copy:templates": "copyfiles \"stubs/**/*.stub\" --up=\"1\" build/stubs",
     "format": "prettier --write .",
     "lint": "eslint . --ext=.ts",
     "prepublishOnly": "yarn build",


### PR DESCRIPTION
Fixes #21 

---

Before this change, the `npm run build` command created a `build` directory that has the config stubs in the wrong place. The copyfiles command during the build copies the `stubs/config/sentry.stub` file into the `build/config/sentry.stub` directory instead of `build/stubs/config/sentry.stub`.

After the change the stub files are copied into the `build/stubs` directory.